### PR TITLE
チャット画面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+models/

--- a/gameEngine/scenes/chat_scene.py
+++ b/gameEngine/scenes/chat_scene.py
@@ -3,19 +3,94 @@ from .base_scene import BaseScene
 
 class ChatScene(BaseScene):
     def __init__(self, scene_manager):
-        super().__init__(scene_manager)
-        self.play_area_width = 192
-        self.play_area_height = 144
-        self.play_area_color = 1
+        super().__init__(scene_manager)        
+        self.chat_area_width = 192
+        self.chat_area_height = 104
+        self.chat_area_color = 1
+        self.y_padding = 4
+        self.x_padding = 5
+
+        self.chat_input_area_width = 192
+        self.chat_input_area_height = 16
+        self.chat_input_area_color = 1
+        self.chat_input_area_text_color = 7
+        self.chat_input_area_text_size = 8
+        self.chat_input_area_x_padding = 5
+        self.chat_input_area_y_padding = 5
+        self.chat_input_bottom_margin = 10
+
+        self.input_text = ""
+        self.chat_text = []
+
+        # スライドバーの設定
+        self.scroll_bar_width = 5
+        self.scroll_bar_color = 7
+
+        # テキストの高さを考慮
+        self.text_size = 8
+        self.text_color = 7
+        
+        # チャットテキストの表示開始インデックスを計算
+        self.max_visible_lines = (self.chat_area_height - self.y_padding * 2) // self.text_size
+        self.start_index = max(0, len(self.chat_text) - self.max_visible_lines)
 
     def update(self):
-        if pyxel.btnp(pyxel.KEY_Q):
-            pyxel.quit()
-        if pyxel.btnp(pyxel.KEY_G):
-            self.scene_manager.set_scene("game_scene")
+        # キー入力を処理して入力文字列を更新
+        for key in range(pyxel.KEY_A, pyxel.KEY_Z + 1):
+            if pyxel.btnp(key):
+                self.input_text += chr(key)
+                # バックスペースキーで文字を削除
+        if pyxel.btnp(pyxel.KEY_BACKSPACE) and len(self.input_text) > 0:
+            self.input_text = self.input_text[:-1]
+        if pyxel.btnp(pyxel.KEY_RETURN):
+            self.chat_text.append(self.input_text)
+            self.input_text = ""
+            if len(self.chat_text) > self.max_visible_lines:
+                self.scroll_offset = min(
+                    len(self.chat_text) - self.max_visible_lines, self.scroll_offset + 1)
+
+        # スクロールオフセットを保持するための変数
+        if not hasattr(self, 'scroll_offset'):
+            self.scroll_offset = 0
+        if pyxel.btnp(pyxel.KEY_UP):
+            self.scroll_offset = max(0, self.scroll_offset - 1)
+        elif pyxel.btnp(pyxel.KEY_DOWN):
+            self.scroll_offset = min(
+                len(self.chat_text) - self.max_visible_lines, self.scroll_offset + 1)
 
     def draw(self):
         pyxel.cls(0)
-        pyxel.rect(0, 0, self.play_area_width, self.play_area_height, self.play_area_color)
-        
-        
+
+        start_x = (self.screen_width - self.chat_area_width) // 2
+        start_y = (self.screen_height - self.chat_area_height) // 5
+        pyxel.rect(start_x, start_y, self.chat_area_width,
+                   self.chat_area_height, self.chat_area_color)
+
+        # スクロールオフセットを考慮してテキストを描画
+        for i, text in enumerate(self.chat_text[self.scroll_offset:self.scroll_offset + self.max_visible_lines]):
+            pyxel.text(start_x + self.x_padding, start_y + self.y_padding + (i * self.text_size), text, self.text_color)
+
+        # スライドバーの描画
+        scroll_bar_x = start_x + self.chat_area_width - self.scroll_bar_width
+        scroll_bar_y = start_y
+        scroll_bar_height = self.chat_area_height
+        pyxel.rect(scroll_bar_x, scroll_bar_y, self.scroll_bar_width,
+                   scroll_bar_height, self.scroll_bar_color)
+
+        # スクロール位置のインジケーター
+        if len(self.chat_text) > self.max_visible_lines:
+            indicator_height = max(
+                10, scroll_bar_height * self.max_visible_lines // len(self.chat_text))
+            indicator_y = scroll_bar_y + (scroll_bar_height - indicator_height) * \
+                self.scroll_offset // (len(self.chat_text) - self.max_visible_lines)
+            pyxel.rect(scroll_bar_x, indicator_y,
+                       self.scroll_bar_width, indicator_height, self.scroll_bar_color)
+
+        input_start_x = (self.screen_width - self.chat_input_area_width) // 2
+        input_start_y = (self.screen_height - self.chat_input_area_height) - self.chat_input_bottom_margin
+        pyxel.rect(input_start_x, input_start_y, self.chat_input_area_width,
+                   self.chat_input_area_height, self.chat_input_area_color)
+        pyxel.text(input_start_x + self.chat_input_area_x_padding, input_start_y + self.chat_input_area_y_padding, ">", self.chat_input_area_text_color)  # 入力プロンプトを表示
+
+        # 入力された文字列を表示
+        pyxel.text(input_start_x + self.chat_input_area_x_padding, input_start_y + self.chat_input_area_y_padding, self.input_text, self.chat_input_area_text_color)

--- a/gameEngine/scenes/chat_scene.py
+++ b/gameEngine/scenes/chat_scene.py
@@ -1,0 +1,21 @@
+import pyxel
+from .base_scene import BaseScene
+
+class ChatScene(BaseScene):
+    def __init__(self, scene_manager):
+        super().__init__(scene_manager)
+        self.play_area_width = 192
+        self.play_area_height = 144
+        self.play_area_color = 1
+
+    def update(self):
+        if pyxel.btnp(pyxel.KEY_Q):
+            pyxel.quit()
+        if pyxel.btnp(pyxel.KEY_G):
+            self.scene_manager.set_scene("game_scene")
+
+    def draw(self):
+        pyxel.cls(0)
+        pyxel.rect(0, 0, self.play_area_width, self.play_area_height, self.play_area_color)
+        
+        

--- a/gameEngine/scenes/game_scene.py
+++ b/gameEngine/scenes/game_scene.py
@@ -60,7 +60,7 @@ class GameScene(BaseScene):
         ]
         self.button_callback = [
             lambda: print("操作ボタンが押されました"),
-            lambda: self.scene_manager.change_scene('chat'),
+            lambda: self.scene_manager.change_scene('roll'),
             lambda: self.scene_manager.change_scene('edit')
         ]
         self.menu_button_text_x_start = self.width - self.menu_area_width

--- a/gameEngine/scenes/game_scene.py
+++ b/gameEngine/scenes/game_scene.py
@@ -1,10 +1,11 @@
 # scenes/game_scene.py
 import pyxel
 from PIL import ImageFont
-from PyxelUniversalFont import Writer # WriterインスタンスはSceneManager経由で渡される想定
+from PyxelUniversalFont import Writer  # WriterインスタンスはSceneManager経由で渡される想定
 from gameEngine.utils.custom_button import Button
 
 from .base_scene import BaseScene
+
 
 class GameScene(BaseScene):
     def __init__(self, scene_manager):
@@ -31,7 +32,7 @@ class GameScene(BaseScene):
         self.height = pyxel.height
         self.font_size = 8
         self.text_color = 2
-        
+
         self.menu_area_width = 64
         self.menu_area_height = 144
         self.menu_area_color = 1
@@ -59,7 +60,7 @@ class GameScene(BaseScene):
         ]
         self.button_callback = [
             lambda: print("操作ボタンが押されました"),
-            lambda: print("会話ボタンが押されました"),
+            lambda: self.scene_manager.change_scene('chat'),
             lambda: self.scene_manager.change_scene('edit')
         ]
         self.menu_button_text_x_start = self.width - self.menu_area_width
@@ -72,15 +73,14 @@ class GameScene(BaseScene):
         # フォントパスもSceneManager側で管理する方が良いかもしれません
 
     def update(self):
-        if pyxel.btnp(pyxel.KEY_Q): # Qで終了はグローバルな処理なのでmain.pyに移管しても良い
-            pyxel.quit() # もしくは self.scene_manager.quit_application() のようなメソッドを呼ぶ
+        if pyxel.btnp(pyxel.KEY_Q):  # Qで終了はグローバルな処理なのでmain.pyに移管しても良い
+            pyxel.quit()  # もしくは self.scene_manager.quit_application() のようなメソッドを呼ぶ
 
-        if pyxel.btnp(pyxel.KEY_T): # 例: Tキーでタイトルシーンへ遷移
+        if pyxel.btnp(pyxel.KEY_T):  # 例: Tキーでタイトルシーンへ遷移
             self.scene_manager.change_scene('title')
-        
-        if pyxel.btnp(pyxel.KEY_E): # 例: Eキーでタイトルシーンへ遷移
-            self.scene_manager.change_scene('edit')
 
+        if pyxel.btnp(pyxel.KEY_E):  # 例: Eキーでタイトルシーンへ遷移
+            self.scene_manager.change_scene('edit')
 
     def draw_checkerboard(self, x_offset, y_offset, width, height, color1, color2):
         for yi in range(height // self.grid_size):
@@ -88,7 +88,8 @@ class GameScene(BaseScene):
                 screen_x = x_offset + xi * self.grid_size
                 screen_y = y_offset + yi * self.grid_size
                 current_color = color1 if (xi + yi) % 2 == 0 else color2
-                pyxel.rect(screen_x, screen_y, self.grid_size, self.grid_size, current_color)
+                pyxel.rect(screen_x, screen_y, self.grid_size,
+                           self.grid_size, current_color)
 
     # draw_text_multiline メソッドはここに残すか、utils.py に移動
     def draw_text_multiline(self, writer_instance, x, y, text, max_width,
@@ -99,7 +100,7 @@ class GameScene(BaseScene):
             print("Error: Writer instance is None.")
             return
 
-        #if not hasattr(writer_instance, 'font_path') or not writer_instance.font_path:
+        # if not hasattr(writer_instance, 'font_path') or not writer_instance.font_path:
         #    print("Error: Writer instance does not have a valid 'font_path' attribute.")
         #    try:
         #        writer_instance.draw(x, y, "[No Font Path]", font_size_to_use, text_color)
@@ -108,91 +109,145 @@ class GameScene(BaseScene):
 
         pillow_font = None
         try:
-            pillow_font = ImageFont.truetype(writer_instance.font_path, font_size_to_use)
+            pillow_font = ImageFont.truetype(
+                writer_instance.font_path, font_size_to_use)
         except IOError:
-            print(f"Error: Could not read font file at '{writer_instance.font_path}'.")
-            try: writer_instance.draw(x, y, "[Font IO Error]", font_size_to_use, text_color)
-            except Exception as e_draw: print(f"Error in fallback draw: {e_draw}")
+            print(
+                f"Error: Could not read font file at '{writer_instance.font_path}'.")
+            try:
+                writer_instance.draw(
+                    x, y, "[Font IO Error]", font_size_to_use, text_color)
+            except Exception as e_draw:
+                print(f"Error in fallback draw: {e_draw}")
             return
         except Exception as e:
             print(f"Error creating Pillow font object: {e}")
-            try: writer_instance.draw(x, y, "[PillowFont Err]", font_size_to_use, text_color)
-            except Exception as e_draw: print(f"Error in fallback draw: {e_draw}")
+            try:
+                writer_instance.draw(
+                    x, y, "[PillowFont Err]", font_size_to_use, text_color)
+            except Exception as e_draw:
+                print(f"Error in fallback draw: {e_draw}")
             return
 
         if not pillow_font:
             print("Error: Pillow font object could not be created.")
-            try: writer_instance.draw(x, y, "[PFont Null Err]", font_size_to_use, text_color)
-            except Exception as e_draw: print(f"Error in fallback draw: {e_draw}")
+            try:
+                writer_instance.draw(
+                    x, y, "[PFont Null Err]", font_size_to_use, text_color)
+            except Exception as e_draw:
+                print(f"Error in fallback draw: {e_draw}")
             return
 
         line_height = font_size_to_use + line_spacing_extra
         if hasattr(pillow_font, 'getmetrics'):
             try:
-                metrics = pillow_font.getmetrics(); font_actual_height = metrics[0]
+                metrics = pillow_font.getmetrics()
+                font_actual_height = metrics[0]
                 line_height = font_actual_height + line_spacing_extra
-            except Exception as e: print(f"Warning: Could not get font metrics: {e}.")
+            except Exception as e:
+                print(f"Warning: Could not get font metrics: {e}.")
         elif hasattr(pillow_font, 'getsize'):
-            try: _, text_h = pillow_font.getsize("A"); line_height = text_h + line_spacing_extra
-            except Exception as e: print(f"Warning: Could not get font legacy size for height: {e}.")
-
-        current_line = ""; current_y = y
-        for char in text:
-            temp_line = current_line + char; current_width = 0
             try:
-                if hasattr(pillow_font, 'getlength'): current_width = int(pillow_font.getlength(temp_line))
+                _, text_h = pillow_font.getsize("A")
+                line_height = text_h + line_spacing_extra
+            except Exception as e:
+                print(
+                    f"Warning: Could not get font legacy size for height: {e}.")
+
+        current_line = ""
+        current_y = y
+        for char in text:
+            temp_line = current_line + char
+            current_width = 0
+            try:
+                if hasattr(pillow_font, 'getlength'):
+                    current_width = int(pillow_font.getlength(temp_line))
                 elif hasattr(pillow_font, 'getbbox'):
-                    if not temp_line: current_width = 0
-                    else: bbox = pillow_font.getbbox(temp_line); current_width = int(bbox[2] - bbox[0])
-                elif hasattr(pillow_font, 'getsize'): text_w, _ = pillow_font.getsize(temp_line); current_width = int(text_w)
+                    if not temp_line:
+                        current_width = 0
+                    else:
+                        bbox = pillow_font.getbbox(temp_line)
+                        current_width = int(bbox[2] - bbox[0])
+                elif hasattr(pillow_font, 'getsize'):
+                    text_w, _ = pillow_font.getsize(temp_line)
+                    current_width = int(text_w)
                 else:
-                    writer_instance.draw(x, current_y, "[WidthCalc Met Err]", font_size_to_use, text_color); return
+                    writer_instance.draw(
+                        x, current_y, "[WidthCalc Met Err]", font_size_to_use, text_color)
+                    return
             except Exception as e:
                 print(f"Error calculating text width for '{temp_line}': {e}")
-                if current_line: writer_instance.draw(x, current_y, current_line, font_size_to_use, text_color)
-                current_y += line_height; current_line = ""; continue
+                if current_line:
+                    writer_instance.draw(
+                        x, current_y, current_line, font_size_to_use, text_color)
+                current_y += line_height
+                current_line = ""
+                continue
 
-            if current_width <= max_width: current_line = temp_line
+            if current_width <= max_width:
+                current_line = temp_line
             else:
-                writer_instance.draw(x, current_y, current_line, font_size_to_use, text_color)
-                current_y += line_height; current_line = char; single_char_width = 0
+                writer_instance.draw(
+                    x, current_y, current_line, font_size_to_use, text_color)
+                current_y += line_height
+                current_line = char
+                single_char_width = 0
                 try:
-                    if hasattr(pillow_font, 'getlength'): single_char_width = int(pillow_font.getlength(char))
+                    if hasattr(pillow_font, 'getlength'):
+                        single_char_width = int(pillow_font.getlength(char))
                     elif hasattr(pillow_font, 'getbbox'):
-                        if not char: single_char_width = 0
-                        else: bbox = pillow_font.getbbox(char); single_char_width = int(bbox[2] - bbox[0])
-                    elif hasattr(pillow_font, 'getsize'): text_w, _ = pillow_font.getsize(char); single_char_width = int(text_w)
-                except: pass
+                        if not char:
+                            single_char_width = 0
+                        else:
+                            bbox = pillow_font.getbbox(char)
+                            single_char_width = int(bbox[2] - bbox[0])
+                    elif hasattr(pillow_font, 'getsize'):
+                        text_w, _ = pillow_font.getsize(char)
+                        single_char_width = int(text_w)
+                except:
+                    pass
                 if single_char_width > max_width and max_width > 0:
-                    print(f"Warning: Char '{char}' ({single_char_width}px) > max_width ({max_width}px). Skipping."); current_line = ""
-        if current_line: writer_instance.draw(x, current_y, current_line, font_size_to_use, text_color)
-
+                    print(
+                        f"Warning: Char '{char}' ({single_char_width}px) > max_width ({max_width}px). Skipping.")
+                    current_line = ""
+        if current_line:
+            writer_instance.draw(x, current_y, current_line,
+                                 font_size_to_use, text_color)
 
     def draw(self):
-        pyxel.cls(0) # 背景クリアは各シーンで行うか、SceneManagerで行うか検討
-        self.draw_checkerboard(0, 0, self.play_area_width, self.screen_height, self.play_bg_color_1, self.play_bg_color_2)
+        pyxel.cls(0)  # 背景クリアは各シーンで行うか、SceneManagerで行うか検討
+        self.draw_checkerboard(0, 0, self.play_area_width, self.screen_height,
+                               self.play_bg_color_1, self.play_bg_color_2)
         if self.writer_play:
-            text_play_x = 5; text_play_y = 5
-            self.writer_play.draw(text_play_x, text_play_y, self.text_play_jp, self.font_point_size, self.text_color_original)
+            text_play_x = 5
+            text_play_y = 5
+            self.writer_play.draw(text_play_x, text_play_y, self.text_play_jp,
+                                  self.font_point_size, self.text_color_original)
 
-        self.draw_checkerboard(self.menu_area_x_start, 0, self.menu_area_width, self.screen_height, self.menu_bg_color_1, self.menu_bg_color_2)
+        self.draw_checkerboard(self.menu_area_x_start, 0, self.menu_area_width,
+                               self.screen_height, self.menu_bg_color_1, self.menu_bg_color_2)
         if self.writer_menu:
-            text_menu_x = self.menu_area_x_start + 5; text_menu_y = 5
+            text_menu_x = self.menu_area_x_start + 5
+            text_menu_y = 5
             drawable_menu_width = self.menu_area_width - 10
             self.draw_text_multiline(
                 self.writer_menu, text_menu_x, text_menu_y, self.text_menu_jp,
                 drawable_menu_width, self.text_color_original,
                 font_size_to_use=self.font_point_size, line_spacing_extra=3
             )
-        
+
         # メニュー画面の描画
         #  背景の配置
-        pyxel.rect(self.menu_main_area_x_start, self.menu_main_area_y_start, self.menu_area_width, self.menu_area_height, self.menu_area_color)
-        pyxel.rect(self.menu_main_area_x_start, self.menu_main_area_y_start, self.menu_area_width, self.menu_main_area_height, self.menu_main_area_color)
-        
+        pyxel.rect(self.menu_main_area_x_start, self.menu_main_area_y_start,
+                   self.menu_area_width, self.menu_area_height, self.menu_area_color)
+        pyxel.rect(self.menu_main_area_x_start, self.menu_main_area_y_start,
+                   self.menu_area_width, self.menu_main_area_height, self.menu_main_area_color)
+
         # textの配置
-        self.writer.draw(self.menu_title_text_x_start, self.menu_title_text_y_start, self.title_text, self.font_size, self.text_color)
-        self.writer.draw(self.menu_main_text_x_start, self.menu_main_text_y_start, self.main_text, self.font_size, self.text_color)
+        self.writer.draw(self.menu_title_text_x_start, self.menu_title_text_y_start,
+                         self.title_text, self.font_size, self.text_color)
+        self.writer.draw(self.menu_main_text_x_start, self.menu_main_text_y_start,
+                         self.main_text, self.font_size, self.text_color)
 
         # ボタンの配置
         for i, text in enumerate(self.button_text):
@@ -213,7 +268,6 @@ class GameScene(BaseScene):
             )
             button.update()
             button.draw()
-
 
     def on_enter(self, previous_scene_name=None, **kwargs):
         print(f"Entered GameScene from {previous_scene_name}")

--- a/gameEngine/scenes/roll_scene.py
+++ b/gameEngine/scenes/roll_scene.py
@@ -1,0 +1,38 @@
+import pyxel
+from gameEngine.scenes.base_scene import BaseScene
+
+class RollScene(BaseScene):
+    def __init__(self, scene_manager):
+        super().__init__(scene_manager)
+        self.roll_area_height = 32
+        self.roll_area_width = 192
+        self.roll_area_x = (self.screen_width - self.roll_area_width) // 2
+        self.roll_area_y = (self.screen_height - self.roll_area_height) // 2
+        self.roll_area_color = 7
+        self.roll_area_text_color = 7
+        self.roll_area_text_size = 10
+
+        self.placeholder_text = "Enter your roll text"
+        self.roll_text = ""
+        self.roll_text_x = (self.screen_width - self.roll_area_width) // 2
+        self.roll_text_y = (self.screen_height - self.roll_area_height) // 2 + self.roll_area_height // 4
+        self.roll_text_color = 8
+        self.roll_text_size = 10
+
+    def update(self):
+        for i in range(pyxel.KEY_A, pyxel.KEY_Z):
+            if pyxel.btnp(i):
+                self.roll_text += chr(i)
+        if pyxel.btnp(pyxel.KEY_RETURN):
+            self.scene_manager.change_scene('chat', roll_text=self.roll_text)
+
+    def draw(self):
+        pyxel.cls(0)
+        pyxel.rect(self.roll_area_x, self.roll_area_y, self.roll_area_width,
+                   self.roll_area_height, self.roll_area_color)
+        if self.roll_text == "":
+            pyxel.text(self.roll_text_x, self.roll_text_y,
+                       self.placeholder_text, self.roll_text_color)
+        else:
+            pyxel.text(self.roll_text_x, self.roll_text_y,
+                       self.roll_text, self.roll_text_color)

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from gameEngine.scene_manager import SceneManager
 from gameEngine.scenes.title_scene import TitleScene
 from gameEngine.scenes.game_scene import GameScene
 from gameEngine.scenes.edit_scene import EditScene
+from gameEngine.scenes.chat_scene import ChatScene
 # PyxelUniversalFont の Writer は SceneManager 内で import されます
 
 # --- アプリケーション設定 ---
@@ -47,6 +48,7 @@ class MainApp:
         self.scene_manager.add_scene('title', TitleScene)
         self.scene_manager.add_scene('game', GameScene)
         self.scene_manager.add_scene('edit', EditScene)
+        self.scene_manager.add_scene('chat', ChatScene)
         # 他のシーンも同様に追加
 
         # 初期シーンの設定

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from gameEngine.scenes.title_scene import TitleScene
 from gameEngine.scenes.game_scene import GameScene
 from gameEngine.scenes.edit_scene import EditScene
 from gameEngine.scenes.chat_scene import ChatScene
+from gameEngine.scenes.roll_scene import RollScene
 # PyxelUniversalFont の Writer は SceneManager 内で import されます
 
 # --- アプリケーション設定 ---
@@ -49,6 +50,7 @@ class MainApp:
         self.scene_manager.add_scene('game', GameScene)
         self.scene_manager.add_scene('edit', EditScene)
         self.scene_manager.add_scene('chat', ChatScene)
+        self.scene_manager.add_scene('roll', RollScene)
         # 他のシーンも同様に追加
 
         # 初期シーンの設定
@@ -57,7 +59,7 @@ class MainApp:
     def run(self):
         if exit_flag:
             return
-        self.scene_manager.run()
+        self.scene_manager.run()    
 
 if __name__ == '__main__':
     app = MainApp()


### PR DESCRIPTION
#20 

以下がまだ対応できていない
- 日本語フォントへの対応
- 変更しやすくする
- 無駄な処理の確認

仕様
- ゲーム画面から会話ボタンから役割を入力できるroll画面に遷移
- roll画面はa~zまで入力でき、returnでchat画面に遷移
- chat画面もa~zまで入力可能
- return(or Enter)で入力可能

途中だけど、確認お願い